### PR TITLE
Changed lang strings disc quota reminder

### DIFF
--- a/classes/usage/quota_manager.php
+++ b/classes/usage/quota_manager.php
@@ -72,13 +72,14 @@ class quota_manager {
         ", array('lastyear' => $lastyear));
         return $a;
     }
-
+// P.T. 20-09-2022, [MDLSAAS-39]: deactivated automatic blockage of a moodle-site and activation of maintenance-mode when disk-quota exceeded
     public function block_site_if_hard_limit_exceeded($used, $hardlimit) {
         global $CFG;
         $blocksite = $used >= $hardlimit;
         if ($blocksite) {
-            $CFG->maintenance_message = get_string('site_blocked_maintenance_message', 'block_disk_quota');
-            enable_cli_maintenance_mode();
+          $CFG->maintenance_message = get_string('site_blocked_maintenance_message', 'block_disk_quota');
+//            $CFG->maintenance_message = get_string('site_blocked_maintenance_message', 'block_disk_quota');
+//            enable_cli_maintenance_mode();
         }
         return $blocksite;
     }
@@ -120,6 +121,9 @@ class quota_manager {
         return $user;
     }
 
+    //P.T. 20-09-2022, [MDLSAAS-39]: adjusted lang-strings + deactivated automatic site blockage when disk-quota exceeded
+    //replaced notification of "site_blocked" with "over_quota", wich informs that quota has been exceeded
+    //for changed lang-strings -> ../../lang/en/block_disk_quota.php (for en, fr, de)
     /**
      * Send notification that the site has been blocked.
      *
@@ -127,7 +131,8 @@ class quota_manager {
      * @param $settings
      */
     public function notify_site_blocked($used, $settings) {
-        $this->notify_if_necessary('site_blocked', $used, $settings);
+      $this->notify_if_necessary('over_quota', $used, $settings);
+//        $this->notify_if_necessary('site_blocked', $used, $settings);
     }
 
     /**

--- a/lang/de/block_disk_quota.php
+++ b/lang/de/block_disk_quota.php
@@ -58,56 +58,43 @@ $string['over_quota_warn_email_frequency'] = 'Frequenz für Speicherplatz-Übers
 $string['over_quota_warn_email_frequency_desc'] = 'Wie häufig Emails gesendet werden, wenn die Speicherplatz-Limite überschritten ist';
 
 // Email strings.
+//P.T. 16.09.2022 [MDLSAAS-39]: replaced lang-strings for the notification email (subjects + body-texts)
 $string['mail_nearing_quota_subject'] = 'Moodle-Instanz nähert sich dem Limit der Speicherplatz-Auslastung';
 $string['mail_nearing_quota_body'] =
-'Ihre Moodle-Instanz {$a->url} nutzt aktuell {$a->used} GB
-des zugewiesenen Speicherplatzes von {$a->quota} GB für Dateien.
+'Verehrte Kundin, verehrter Kunde,
+mit dieser E-Mail möchten wir Sie gerne darauf hinweisen, dass Ihre Moodle-Website bald ihr Datenkontingent ausgeschöpft haben wird.
 
-Falls Sie mehr Speicherplatz benötigen, kontaktieren Sie uns bitte
-umgehend. Alternativ empfehlen wir Ihnen, benutzten Speicherplatz
-freizugeben, indem Sie nicht benötigte Dateien löschen.
+Ihre Moodle-Website {$a->url} verbraucht derzeit {$a->used} GB des zugewiesenen {$a->quota} GB Speicherplatzes für Dateien.
 
-Jetzt wäre der richtige Zeitpunkt, um mehr Speicherplatz zu bestellen,
-oder alte Dateien zu löschen.
+Wenn Sie mehr Speicherplatz benötigen, können Sie uns gerne direkt über maas@liip.ch kontaktieren. 10 GB an zusätzlichem Speicherplatz kosten CHF 30,- pro Jahr.
 
-Falls der zugewiesene Speicherplatz zu stark überschritten wird, wird
-Ihre Moodle-Instanz automatisch in den Wartungs-Modus versetzt und ist
-für die Benutzer nicht mehr verfügbar.
+
+Alternativ empfehlen wir Ihnen, Ihren Speicherplatz zu reduzieren, indem Sie ungenutzte Dateien oder nicht mehr benötigte Kurs-Backups löschen.
+
 
 {$a->signature}
 ';
 
-$string['mail_over_quota_subject'] = 'Moodle-Instanz hat die Limite der Speicherplatz-Auslastung überschritten';
+$string['mail_over_quota_subject'] = 'Wichtig: Moodle-Instanz hat das Limit der Speicherplatz-Auslastung überschritten';
 $string['mail_over_quota_body'] =
-'Ihre Moodle-Instanz {$a->url} nutzt aktuell {$a->used} GB
-des zugewiesenen Speicherplatzes von {$a->quota} GB für Dateien.
+'Verehrte Kundin, verehrter Kunde,
+mit dieser E-Mail möchten wir Sie gerne darauf hinweisen, dass Ihre Moodle-Website das vorgesehene Datenkontingent bereits ausgeschöpft hat und damit das Limit der Speicherplatz-Auslastung überschritten ist.
 
-Bitte kontaktieren Sie uns umgehend, für eine Erhöhung des
-Speicherplatzes. Sie können entweder mehr Speicherplatz bestellen,
-oder unbenutzte Dateien löschen.
+Ihre Moodle-Website {$a->url} verbraucht derzeit {$a->used} GB des zugewiesenen {$a->quota} GB Speicherplatzes für Dateien.
 
-Falls der zugewiesene Speicherplatz zu stark überschritten wird, wird
-Ihre Moodle-Instanz automatisch in den Wartungs-Modus versetzt und ist
-für die Benutzer nicht mehr verfügbar.
+Bitte kontaktieren Sie uns umgehend für ein Upgrade.
+Um eine automatische Wartung Ihrer Moodle-Seite zu vermeiden, können Sie entweder mehr Speicherplatz bestellen oder den Speicherplatzverbrauch reduzieren, indem Sie beispielsweise ungenutzte Dateien oder nicht mehr benötigte Kurs-Backups löschen.
+
+Wenn Sie mehr Speicherplatz benötigen, können Sie uns gerne direkt über maas@liip.ch kontaktieren. 10 GB an zusätzlichem Speicherplatz kosten CHF 30.- pro Jahr.
+
 
 {$a->signature}
 ';
 
-$string['mail_site_blocked_subject'] = 'Wichtig: Moodle-Instanz deaktiviert wegen übermässigem Speicherplatz-Verbrauch';
+/***P.T. 16.09.2022 [MDLSAAS-39]: removed lang-strings for the following notification email:
+$string['mail_site_blocked_subject'] = 'Important: Moodle site has been disabled due to excessive disk usage';
 $string['mail_site_blocked_body'] =
-'Ihre Moodle-Instanz {$a->url} nutzt aktuell {$a->used} GB
-des zugewiesenen Speicherplatzes von {$a->quota} GB für Dateien.
-
-Sie haben bereits mehrere Warnung per Email erhalten, mit der Bitte,
-mehr Speicherplatz für Ihr Moodle zu bestellen. Ohne Feedback von Ihnen
-wurde Ihre Moodle-Instanz automatisch deaktiviert, um negative
-Auswirkungen auf unsere Infrastruktur und andere Kunden zu verhindern.
-
-Bitte kontaktieren Sie uns schnellstmöglich, damit wir gemeinsam eine
-Lösung finden können.
-
-{$a->signature}
-';
+*/
 
 $string['mail_signature'] = 'Mit freundlichen Grüssen
 Liip Elearning Team

--- a/lang/de/block_disk_quota.php
+++ b/lang/de/block_disk_quota.php
@@ -92,7 +92,7 @@ Wenn Sie mehr Speicherplatz benötigen, können Sie uns gerne direkt über maas@
 ';
 
 /***P.T. 16.09.2022 [MDLSAAS-39]: removed lang-strings for the following notification email:
-$string['mail_site_blocked_subject'] = 'Important: Moodle site has been disabled due to excessive disk usage';
+$string['mail_site_blocked_subject'] = 'Wichtig: Moodle-Instanz deaktiviert wegen übermässigem Speicherplatz-Verbrauch';
 $string['mail_site_blocked_body'] =
 */
 

--- a/lang/en/block_disk_quota.php
+++ b/lang/en/block_disk_quota.php
@@ -68,54 +68,45 @@ $string['over_quota_warn_email_frequency'] = 'Over quota warn frequency';
 $string['over_quota_warn_email_frequency_desc'] = 'How often mails will be sent when the site has exceeded the quota';
 
 // Email strings.
+//P.T. 16.09.2022 [MDLSAAS-39]: replaced lang-strings for the notification email (subjects + body-texts) 
 $string['mail_nearing_quota_subject'] = 'Moodle site is nearing quota limit';
 $string['mail_nearing_quota_body'] =
-'Your Moodle site {$a->url} is currently using {$a->used} GB
-of the allocated {$a->quota} GB space for files.
+'Dear client,
+This email is a kind reminder that your Moodle site is nearing the limit of its data quota.
 
-If you need more disk space, please contact us asap to
-upgrade. Alternatively, we suggest that you reduce your disk
-usage by deleting unused data.
+Your Moodle site {$a->url} is currently using {$a->used} GB of the allocated {$a->quota} GB space for files.
 
-Now would be a good time to order more space, or to reduce
-your space used.
+If you need more disk space, you can contact us directly via maas@liip.ch. 10 GB extra storage space costs CHF 30,- per year.
 
-If your Moodle goes too far over the disk space limit, it will
-be automatically put into maintenance mode and will be unavailable
-for users.
+
+Alternatively, we suggest that you reduce your disk usage by deleting unused data (e.g. unused files or course backups).
+
 
 {$a->signature}
 ';
 
-$string['mail_over_quota_subject'] = 'Moodle site has exceeded quota limit';
+//P.T. 16.09.2022 [MDLSAAS-39]: replaced lang-strings for the notification email (subjects + body-texts)
+$string['mail_over_quota_subject'] = 'Important: Moodle site has exceeded disk quota limit';
 $string['mail_over_quota_body'] =
-'Your Moodle site {$a->url} is currently using {$a->used} GB
-of the allocated {$a->quota} GB space for files.
+'Dear client,
+This email is a kind reminder that your Moodle site has already exceeded the limit of its data quota.
 
-Please contact us immediately to upgrade. You may either order
-more disk space, or reduce disk usage by deleting unused data.
+Your Moodle site {$a->url} is currently using {$a->used} GB of the allocated {$a->quota} GB space for files.
 
-If your Moodle goes too far over the disk space limit, it will
-be automatically put into maintenance mode and will be unavailable
-for users.
+Please contact us immediately to upgrade. In order to avoid automatic maintenance of your site, you may either order
+more disk space, or reduce disk usage by deleting unused data immediately (e.g. unused files or course backups).
+
+
+If you need more disk space, you can contact us directly via maas@liip.ch. 10 GB extra storage space costs CHF 30,- per year.
+
 
 {$a->signature}
 ';
 
+/***P.T. 16.09.2022 [MDLSAAS-39]: removed lang-strings for the following notification email:
 $string['mail_site_blocked_subject'] = 'Important: Moodle site has been disabled due to excessive disk usage';
 $string['mail_site_blocked_body'] =
-'Your Moodle site {$a->url} is currently using {$a->used} GB
-of the allocated {$a->quota} GB space for files.
-
-You have received several warnings mails requesting you to upgrade
-your Moodle hosting plan. With no feedback from your side, your
-Moodle instance has been deactivated automatically in order to avoid
-impact on our infrastructure and other hosted projects.
-
-Please contact us immediately to find a solution.
-
-{$a->signature}
-';
+*/
 
 $string['mail_signature'] = 'With friendly greetings,
 The Liip Elearning Team

--- a/lang/fr/block_disk_quota.php
+++ b/lang/fr/block_disk_quota.php
@@ -60,60 +60,44 @@ $string['over_quota_warn_email_frequency'] = 'Fréquence des notifications de qu
 $string['over_quota_warn_email_frequency_desc'] = 'A quelle fréquence les mails de notification seront-ils envoyés lorsque l\'espace occupé par le site dépasse son quota';
 
 // Email strings.
-$string['mail_nearing_quota_subject'] = 'Votre instance Moodle approche de son quota limite';
+//P.T. 16.09.2022 [MDLSAAS-39]: replaced lang-strings for the notification email (subjects + body-texts)
+$string['mail_nearing_quota_subject'] = 'Votre instance Moodle approche de sa quota limite';
 $string['mail_nearing_quota_body'] =
-'Votre instance Moodle {$a->url} utilise actuellement {$a->used} GB
-des {$a->quota} alloués pour ses données.
+'Cher client,
+Cet email est un rappel en ce qui concerne votre instance Moodle, cette dernière est proche d’atteindre la limite de son quota.
 
-Si vous avez besoin de plus d\'espace, nous vous prions de commander
-une augmentation de la capacité de stockage. Nous vous suggérons
-d’éventuellement réduire l\'espace disque utilisé en supprimant des
-données inutiles.
+Votre instance Moodle {$a->url} utilise actuellement {$a->used} Go d’espace, vous avez à disposition {$a->quota} GO.
 
-Lorsque l\'espace disque utilisé par votre instance Moodle dépasse la limite
-contractuelle d\'une trop grande marge, automatiquement celle-ci n’est plus
-disponible pour les utilisateurs. Un message automatique de mise en maintenance
-est activé.
+Afin de pallier ce problème, nous vous proposons de supprimer les données non utilisées ou de nous contacter pour augmenter la taille de votre espace.
+
+N’hésitez pas à nous contacter directement à maas@liip.ch, nous sommes là pour vous assister. Le coût d’un espace de stockage supplémentaire est de CHF 30.- par année, pour 10 Go supplémentaires.
+
 
 {$a->signature}
 ';
 
-$string['mail_over_quota_subject'] = 'Le site Moodle a dépassé son quota limite';
+//P.T. 16.09.2022 [MDLSAAS-39]: replaced lang-strings for the notification email (subjects + body-texts)
+$string['mail_over_quota_subject'] = 'Important: Votre site Moodle a dépassé son quota limite';
 $string['mail_over_quota_body'] =
-'Votre instance Moodle {$a->url} utilise actuellement {$a->used} GB
-des {$a->quota} alloués pour ses données.
+'Cher client,
+Cet email est un rappel en ce qui concerne votre instance Moodle, cette dernière a dépassé la limite de quota en termes de données.
 
-Pourriez vous nous contacter au plus vite pour résoudre cette situation.
-Il vous est possible, soit de commander plus d\'espace disque, soit de
-réduire l\'espace disque utilisé en supprimant des données.
+Votre instance Moodle {$a->url} utilise actuellement {$a->used} Go d’espace, vous avez à disposition {$a->quota} Go.
 
-Lorsque l\'espace disque utilisé par votre instance Moodle dépasse la limite
-contractuelle d\'une trop grande marge, automatiquement celle-ci n’est plus
-disponible pour les utilisateurs. Un message automatique de mise en maintenance
-est activé.
+Afin de pallier ce problème, nous vous proposons de supprimer les données non utilisées ou de nous contacter pour augmenter la taille de votre espace.
 
-Veuillez nous contacter pour éviter cette situation, nous vous proposerons volontiers
-une mise à jour.
+Afin d’éviter une mise en maintenance automatique du système, merci de prendre vos dispositions nécessaires pour réduire votre espace.
+
+N’hésitez pas à nous contacter directement à maas@liip.ch, nous sommes là pour vous assister. Le coût d’un espace de stockage supplémentaire est de CHF 30.- par année, pour 10 Go supplémentaires.
+
 
 {$a->signature}
 ';
 
+/***P.T. 16.09.2022 [MDLSAAS-39]: removed lang-strings for the following notification email:
 $string['mail_site_blocked_subject'] = 'Important: Votre instance Moodle est désactivée';
 $string['mail_site_blocked_body'] =
-'Votre instance Moodle {$a->url} utilise actuellement {$a->used} GB
-des {$a->quota} alloués pour ses données.
-
-Vous avez reçu plusieurs mails d\'avertissement vous demandant de nous
-contacter pour mettre à jour la capacité de stockage des données. Sans
-réponse de votre part, celle-ci a été désactivée automatiquement pour
-éviter d\'impacter la qualité de notre infrastructure et des autres
-projets hébergés.
-
-Pourriez vous nous contacter immédiatement afin de nous permettre de
-trouver ensemble une solution.
-
-{$a->signature}
-';
+*/
 
 $string['mail_signature'] = 'Avec nos sincères salutations,
 La Team Elearning de Liip


### PR DESCRIPTION
Hii, here's what has been changed:

in "lang/en/block_disk_quota.php" (as for fr, de)
- adjusted language-strings for en, fr, de 
- removed notification text/strings for "site-blocked" messages

in "classes/usage/quota_manager.php" 
- quoted passages that are responsible for automatic site blockage 
- replaced call for notification message for "site_blocked" with the one for "over_quota" 


What is still TODO:
- setting up notifications for "user-quota" analogue to that of "disk-quota" (nearing, exceeded user-quota)