### PR TITLE
Option for automatic site blockage

### DIFF
--- a/lang/de/block_disk_quota.php
+++ b/lang/de/block_disk_quota.php
@@ -33,12 +33,17 @@ $string['gigabytes_used'] = 'GB benutzt';
 // Settings strings.
 $string['enabled'] = 'Aktivieren';
 $string['enabled_desc'] = 'Speicherplatz-Limite aktivieren';
+
+//P.T. 29-09-2022: additional strings for 'block_site_enabled' and 'block_site_enabled_desc'
+$string['block_site_enabled'] = 'Seite automatisch deaktivieren';
+$string['block_site_enabled_desc'] = 'Aktivierung der automatischen Seiten-Blockierung nach Überschreitung der Speicherplatz-Limite und nach Ausschöpfung des erlaubten Mehrverbrauchs an Gigabyte';
+
 $string['quota_gb'] = 'Speicherplatz-Limite';
 $string['quota_gb_desc'] = 'Speicherplatz-Limite in Gigabyte';
 $string['warn_when_within_gb_of_limit'] = 'Warnen wenn in der Nähe des Limits';
 $string['warn_when_within_gb_of_limit_desc'] = 'Eine Warnung an die definierten Benutzer senden, wenn die Speicherplatz-Auslastung innerhalb von X GB des Limits ist';
 $string['overage_limit_gb'] = 'Erlaube die Überschreitung des Limits um';
-$string['overage_limit_gb_desc'] = 'Um wieviele Gigabytes das Limit der Speicherplatz-Auslastung überschritten werden darf, bevor die Seite automatisch deaktiviert wird.';
+$string['overage_limit_gb_desc'] = 'Um wie viele Gigabytes das Limit der Speicherplatz-Auslastung überschritten werden darf, bevor die Seite automatisch deaktiviert wird.';
 $string['do_email_admins'] = 'Email an Administratoren versenden?';
 $string['do_email_admins_desc'] = 'Sollen alle Benutzer mit Administratoren-Rechten Warnungen und "Seite deaktiviert"-Benachrichtigungen erhalten?';
 $string['email_others'] = 'Weitere Email-Adressen';
@@ -68,11 +73,27 @@ umgehend. Alternativ empfehlen wir Ihnen, benutzten Speicherplatz
 freizugeben, indem Sie nicht benötigte Dateien löschen.
 
 Jetzt wäre der richtige Zeitpunkt, um mehr Speicherplatz zu bestellen,
-oder alte Dateien zu löschen.
+oder um alte Dateien zu löschen.
 
 Falls der zugewiesene Speicherplatz zu stark überschritten wird, wird
 Ihre Moodle-Instanz automatisch in den Wartungs-Modus versetzt und ist
 für die Benutzer nicht mehr verfügbar.
+
+{$a->signature}
+';
+
+//P.T. 29-09-2022 added changed lang-strings for notification messages when automatic site block disabled
+$string['mail_nearing_quota_noblock_subject'] = 'Moodle-Instanz nähert sich dem Limit der Speicherplatz-Auslastung';
+$string['mail_nearing_quota_noblock_body'] =
+'Ihre Moodle-Instanz {$a->url} nutzt aktuell {$a->used} GB
+des zugewiesenen Speicherplatzes von {$a->quota} GB für Dateien.
+
+Falls Sie mehr Speicherplatz benötigen, kontaktieren Sie uns bitte
+umgehend. Alternativ empfehlen wir Ihnen, benutzten Speicherplatz
+freizugeben, indem Sie nicht benötigte Dateien löschen.
+
+Jetzt wäre der richtige Zeitpunkt, um mehr Speicherplatz zu bestellen,
+oder um alte Dateien zu löschen.
 
 {$a->signature}
 ';
@@ -89,6 +110,19 @@ oder unbenutzte Dateien löschen.
 Falls der zugewiesene Speicherplatz zu stark überschritten wird, wird
 Ihre Moodle-Instanz automatisch in den Wartungs-Modus versetzt und ist
 für die Benutzer nicht mehr verfügbar.
+
+{$a->signature}
+';
+
+//P.T. 29-09-2022 added changed lang-strings for notification messages when automatic site block disabled
+$string['mail_over_quota_noblock_subject'] = 'Wichtig: Moodle-Instanz hat die Limite der Speicherplatz-Auslastung überschritten';
+$string['mail_over_quota_noblock_body'] =
+'Ihre Moodle-Instanz {$a->url} nutzt aktuell {$a->used} GB
+des zugewiesenen Speicherplatzes von {$a->quota} GB für Dateien.
+
+Bitte kontaktieren Sie uns umgehend, für eine Erhöhung des
+Speicherplatzes. Sie können entweder mehr Speicherplatz bestellen,
+oder unbenutzte Dateien löschen.
 
 {$a->signature}
 ';

--- a/lang/de/block_disk_quota.php
+++ b/lang/de/block_disk_quota.php
@@ -41,18 +41,18 @@ $string['block_site_enabled_desc'] = 'Aktivierung der automatischen Seiten-Block
 $string['quota_gb'] = 'Speicherplatz-Limite';
 $string['quota_gb_desc'] = 'Speicherplatz-Limite in Gigabyte';
 $string['warn_when_within_gb_of_limit'] = 'Warnen wenn in der Nähe des Limits';
-$string['warn_when_within_gb_of_limit_desc'] = 'Eine Warnung an die definierten Benutzer senden, wenn die Speicherplatz-Auslastung innerhalb von X GB des Limits ist';
+$string['warn_when_within_gb_of_limit_desc'] = 'Eine Warnung an die definierten Benutzer*innen senden, wenn die Speicherplatz-Auslastung innerhalb von X GB des Limits ist';
 $string['overage_limit_gb'] = 'Erlaube die Überschreitung des Limits um';
-$string['overage_limit_gb_desc'] = 'Um wie viele Gigabytes das Limit der Speicherplatz-Auslastung überschritten werden darf, bevor die Seite automatisch deaktiviert wird.';
-$string['do_email_admins'] = 'Email an Administratoren versenden?';
-$string['do_email_admins_desc'] = 'Sollen alle Benutzer mit Administratoren-Rechten Warnungen und "Seite deaktiviert"-Benachrichtigungen erhalten?';
+$string['overage_limit_gb_desc'] = 'Um wie viele Gigabytes das Limits der Speicherplatz-Auslastung überschritten werden darf, bevor die Seite automatisch deaktiviert wird.';
+$string['do_email_admins'] = 'Email an Administrator*innen versenden?';
+$string['do_email_admins_desc'] = 'Sollen alle Benutzer*innen mit Administrator*innen-Rechten Warnungen und "Seite deaktiviert"-Benachrichtigungen erhalten?';
 $string['email_others'] = 'Weitere Email-Adressen';
 $string['email_others_desc'] = 'Weitere Email-Adressen, welche Benachrichtigungen erhalten. Mehrere Adressen '
     .'mit Komma separieren (user1@example.com, user2@example.org, user3@example.net)';
 
 $string['err_invalid_email_address'] = 'Die Email-Adresse an der Stelle {$a} ist keine gültige Email-Adresse';
 $string['site_blocked_maintenance_message'] = 'Die Seite ist zur Zeit nicht verfügbar, da die Speicherplatz-Limite erheblich überschritten wurde. '
-    .'Administrator: bitte kontaktieren Sie den Support, um das Problem zu lösen.';
+    .'Administrator*in: bitte kontaktieren Sie den Support, um das Problem zu lösen.';
 $string['support_telephone'] = 'Support Telefon';
 $string['support_telephone_desc'] = 'Support Telefonnummer für dringende Fälle';
 $string['support_email'] = 'Support-Email';
@@ -77,7 +77,7 @@ oder um alte Dateien zu löschen.
 
 Falls der zugewiesene Speicherplatz zu stark überschritten wird, wird
 Ihre Moodle-Instanz automatisch in den Wartungs-Modus versetzt und ist
-für die Benutzer nicht mehr verfügbar.
+für die Benutzer*innen nicht mehr verfügbar.
 
 {$a->signature}
 ';
@@ -109,7 +109,7 @@ oder unbenutzte Dateien löschen.
 
 Falls der zugewiesene Speicherplatz zu stark überschritten wird, wird
 Ihre Moodle-Instanz automatisch in den Wartungs-Modus versetzt und ist
-für die Benutzer nicht mehr verfügbar.
+für die Benutzer*innen nicht mehr verfügbar.
 
 {$a->signature}
 ';

--- a/lang/en/block_disk_quota.php
+++ b/lang/en/block_disk_quota.php
@@ -38,6 +38,11 @@ $string['task_send_heartbeat_email'] = 'Send a heartbeat email to check email tr
 // Settings strings.
 $string['enabled'] = 'Enabled';
 $string['enabled_desc'] = 'Whether the disk quota check is enforced';
+
+//P.T. 29-09-2022: additional strings for 'block_site_enabled' and 'block_site_enabled_desc'
+$string['block_site_enabled'] = 'Block site automatically';
+$string['block_site_enabled_desc'] = 'Whether the automatic site blockage is enabled in case of exceeding disk quota beyond the allowed limit ovarage';
+
 $string['quota_gb'] = 'Disk Quota';
 $string['quota_gb_desc'] = 'Disk Quota in gigabytes';
 $string['quota_activeusers'] = 'Active users Quota';
@@ -67,6 +72,12 @@ $string['nearing_quota_warn_email_frequency_desc'] = 'How often mails will be se
 $string['over_quota_warn_email_frequency'] = 'Over quota warn frequency';
 $string['over_quota_warn_email_frequency_desc'] = 'How often mails will be sent when the site has exceeded the quota';
 
+/*
+//P.T. 29-09-2022
+$string['over_quota_noblock_warn_email_frequency'] = '(noblock)Over quota warn frequency';
+$string['over_quota_noblock_warn_email_frequency_desc'] = '(noblock)How often mails will be sent when the site has exceeded the quota';
+*/
+
 // Email strings.
 $string['mail_nearing_quota_subject'] = 'Moodle site is nearing quota limit';
 $string['mail_nearing_quota_body'] =
@@ -87,6 +98,22 @@ for users.
 {$a->signature}
 ';
 
+//P.T. 29-09-2022 added changed lang-strings for notification messages when automatic stite block disabled
+$string['mail_nearing_quota_noblock_subject'] = 'Moodle site is nearing quota limit';
+$string['mail_nearing_quota_noblock_body'] =
+'Your Moodle site {$a->url} is currently using {$a->used} GB
+of the allocated {$a->quota} GB space for files.
+
+If you need more disk space, please contact us asap to
+upgrade. Alternatively, we suggest that you reduce your disk
+usage by deleting unused data.
+
+Now would be a good time to order more space, or to reduce
+your space used.
+
+{$a->signature}
+';
+
 $string['mail_over_quota_subject'] = 'Moodle site has exceeded quota limit';
 $string['mail_over_quota_body'] =
 'Your Moodle site {$a->url} is currently using {$a->used} GB
@@ -101,6 +128,20 @@ for users.
 
 {$a->signature}
 ';
+
+//P.T. 29-09-2022 added changed lang-strings for notification messages when automatic stite block disabled
+
+$string['mail_over_quota_noblock_subject'] = 'Important: Moodle site has exceeded quota limit';
+$string['mail_over_quota_noblock_body'] =
+'Your Moodle site {$a->url} is currently using {$a->used} GB
+of the allocated {$a->quota} GB space for files.
+
+Please contact us immediately to upgrade. You may either order
+more disk space, or reduce disk usage by deleting unused data.
+
+{$a->signature}
+';
+
 
 $string['mail_site_blocked_subject'] = 'Important: Moodle site has been disabled due to excessive disk usage';
 $string['mail_site_blocked_body'] =

--- a/lang/en/block_disk_quota.php
+++ b/lang/en/block_disk_quota.php
@@ -41,8 +41,7 @@ $string['enabled_desc'] = 'Whether the disk quota check is enforced';
 
 //P.T. 29-09-2022: additional strings for 'block_site_enabled' and 'block_site_enabled_desc'
 $string['block_site_enabled'] = 'Block site automatically';
-$string['block_site_enabled_desc'] = 'Whether the automatic site blockage is enabled in case of exceeding disk quota beyond the allowed limit ovarage';
-
+$string['block_site_enabled_desc'] = 'Whether the automatic site blockage is enabled in case of exceeding disk quota beyond the allowed limit overage';
 $string['quota_gb'] = 'Disk Quota';
 $string['quota_gb_desc'] = 'Disk Quota in gigabytes';
 $string['quota_activeusers'] = 'Active users Quota';
@@ -57,7 +56,6 @@ $string['do_email_admins_desc'] = 'Should all admin users receive warning and si
 $string['email_others'] = 'Additional emails';
 $string['email_others_desc'] = 'Additional email addresses to use when sending out notifications. Separate multiple '
     .'addresses with a comma (e.g. user1@example.com, user2@example.org, user3@example.net)';
-
 $string['err_invalid_email_address'] = 'The email address in position {$a} is not a valid email address';
 $string['site_blocked_maintenance_message'] = 'The site is currently unavailable because the disk quota has been '
     .' largely surpassed.  Administrator: please contact support to help resolve this problem.';
@@ -72,11 +70,6 @@ $string['nearing_quota_warn_email_frequency_desc'] = 'How often mails will be se
 $string['over_quota_warn_email_frequency'] = 'Over quota warn frequency';
 $string['over_quota_warn_email_frequency_desc'] = 'How often mails will be sent when the site has exceeded the quota';
 
-/*
-//P.T. 29-09-2022
-$string['over_quota_noblock_warn_email_frequency'] = '(noblock)Over quota warn frequency';
-$string['over_quota_noblock_warn_email_frequency_desc'] = '(noblock)How often mails will be sent when the site has exceeded the quota';
-*/
 
 // Email strings.
 $string['mail_nearing_quota_subject'] = 'Moodle site is nearing quota limit';
@@ -98,7 +91,7 @@ for users.
 {$a->signature}
 ';
 
-//P.T. 29-09-2022 added changed lang-strings for notification messages when automatic stite block disabled
+//P.T. 29-09-2022 added changed lang-strings for notification messages when automatic site block disabled
 $string['mail_nearing_quota_noblock_subject'] = 'Moodle site is nearing quota limit';
 $string['mail_nearing_quota_noblock_body'] =
 'Your Moodle site {$a->url} is currently using {$a->used} GB
@@ -129,8 +122,7 @@ for users.
 {$a->signature}
 ';
 
-//P.T. 29-09-2022 added changed lang-strings for notification messages when automatic stite block disabled
-
+//P.T. 29-09-2022 added changed lang-strings for notification messages when automatic site block disabled
 $string['mail_over_quota_noblock_subject'] = 'Important: Moodle site has exceeded quota limit';
 $string['mail_over_quota_noblock_body'] =
 'Your Moodle site {$a->url} is currently using {$a->used} GB

--- a/lang/fr/block_disk_quota.php
+++ b/lang/fr/block_disk_quota.php
@@ -23,30 +23,35 @@
  */
 $string['pluginname'] = 'Quota d\'utilisation Liip';
 $string['disk_quota:addinstance'] = 'Ajouter un nouveau bloc Quota de disque';
-$string['disk_quota:myaddinstance'] = 'Ajouter un nouveau bloc Quota de disque à ma Dashboard';
-$string['disk_quota:viewblock'] = 'un bloc Quota de disque';
+$string['disk_quota:myaddinstance'] = 'Ajouter un nouveau bloc Quota de disque à mon Dashboard';
+$string['disk_quota:viewblock'] = 'Voir un bloc Quota de disque';
 $string['disk_quota:viewusage'] = 'Voir les détails de l\'utilisation du quota';
 $string['err_cannot_uninstall_plugin'] = 'Ce plugin ne peut pas être désinstallé';
 $string['quota_used'] = '{$a->used} de {$a->quota} GB utilisés';
 $string['gigabytes_used'] = 'GB utilisés';
 
 // Tasks.
-$string['task_get_disk_usage'] = 'Enregistrer l\'utilisation d\'espace disque';
+$string['task_get_disk_usage'] = 'Obtenir l\'utilisation de l\'espace disque';
 
 // Settings strings.
 $string['enabled'] = 'Actif';
-$string['enabled_desc'] = 'Activer la vérification de quota de disque';
+$string['enabled_desc'] = 'Si la vérification du quota de l\'espace disque est appliquée';
+
+//P.T. 29-09-2022: additional strings for 'block_site_enabled' and 'block_site_enabled_desc'
+$string['block_site_enabled'] = 'Désactivation automatique du site';
+$string['block_site_enabled_desc'] = 'Activation du blocage automatique du site après dépassement de la limite de l\'espace disque au dela de la limite autorisée.';
+
 $string['quota_gb'] = 'Quota de disque';
 $string['quota_gb_desc'] = 'Quota de disque en gigabytes';
-$string['quota_activeusers'] = 'Quota d\'utilisateurs actifs';
-$string['quota_activeusers_desc'] = 'Quota d\'utilisateurs actifs (connectés dans les 6 derniers mois)';
-$string['warn_when_within_gb_of_limit'] = 'Prévenir quand la différence entre l\'espace utilisé et le quota atteint cette limite';
-$string['warn_when_within_gb_of_limit_desc'] = 'Envoie un avertissement à l\'utilisateur choisi quand l\'espace disque est compris dans la limite définie';
-$string['overage_limit_gb'] = 'Allow exceeding limit by';
+$string['quota_activeusers'] = 'Quota d\'utilisateurs·rices actif·ves';
+$string['quota_activeusers_desc'] = 'Quota d\'utilisateur·trices actif·ves (connectés dans les 12 derniers mois)';
+$string['warn_when_within_gb_of_limit'] = 'Prévenir quand le quota s\'approche de cette limit';
+$string['warn_when_within_gb_of_limit_desc'] = 'Envoie un avertissement aux utilisateur·trices prédefinis lorsque l\'utilisation de \'espace disque se situe dans les X GB de la limite';
+$string['overage_limit_gb'] = 'Autoriser un dépassement de la limite de';
 $string['overage_limit_gb_desc'] = 'Dépassement d\'espace disque toléré avant que le site soit automatiquement désactivé';
-$string['do_email_admins'] = 'Prévenir les administrateurs?';
-$string['do_email_admins_desc'] = 'Est-ce que les utilisateurs ayant des droits d\'administrateur doivent recevoir les notifications?';
-$string['email_others'] = 'Utilisateurs notifiés additionnels';
+$string['do_email_admins'] = 'Prévenir les administrateur·trices?';
+$string['do_email_admins_desc'] = 'Est-ce que les tous·tes les administrateur·trices doivent recevoir les notifications?';
+$string['email_others'] = 'Emails additionnels';
 $string['email_others_desc'] = 'Addresses mail additionnelles à utiliser lorsque des notifications sont envoyées. Séparez des addresses mutltiples avec une virgule (exemple : user1@exemple.com, user2@exemple.org, user3@exemple.net)';
 $string['err_invalid_email_address'] = 'L\'addresse email en position {$a} n\'est pas une addresse email valide';
 $string['site_blocked_maintenance_message'] = 'Le site est actuellement indisponible car le quota disque a été largement dépassé. Administrateur: Veuillez contacter le support pour aider à résoudre ce problème';
@@ -78,6 +83,20 @@ est activé.
 {$a->signature}
 ';
 
+//P.T. 29-09-2022 added changed lang-strings for notification messages when automatic site block disabled
+$string['mail_nearing_quota_noblock_subject'] = 'Votre instance Moodle approche de son quota limite';
+$string['mail_nearing_quota_noblock_body'] =
+'Votre instance Moodle {$a->url} utilise actuellement {$a->used} GB
+des {$a->quota} alloués pour ses données.
+
+Si vous avez besoin de plus d\'espace, nous vous prions de commander
+une augmentation de la capacité de stockage. Nous vous suggérons
+d’éventuellement réduire l\'espace disque utilisé en supprimant des
+données inutiles.
+
+{$a->signature}
+';
+
 $string['mail_over_quota_subject'] = 'Le site Moodle a dépassé son quota limite';
 $string['mail_over_quota_body'] =
 'Votre instance Moodle {$a->url} utilise actuellement {$a->used} GB
@@ -94,6 +113,19 @@ est activé.
 
 Veuillez nous contacter pour éviter cette situation, nous vous proposerons volontiers
 une mise à jour.
+
+{$a->signature}
+';
+
+//P.T. 29-09-2022 added changed lang-strings for notification messages when automatic site block disabled
+$string['mail_over_quota_noblock_subject'] = 'Important: Le site Moodle a dépassé son quota limite';
+$string['mail_over_quota_noblock_body'] =
+'Votre instance Moodle {$a->url} utilise actuellement {$a->used} GB
+des {$a->quota} alloués pour ses données.
+
+Pourriez vous nous contacter au plus vite pour résoudre cette situation.
+Il vous est possible, soit de commander plus d\'espace disque, soit de
+réduire l\'espace disque utilisé en supprimant des données.
 
 {$a->signature}
 ';

--- a/settings.php
+++ b/settings.php
@@ -88,16 +88,6 @@ if ($ADMIN->fulltree) {
         14 * 24 * 60 * 60
     ));
 
-/*
-//original
-    $settings->add(new admin_setting_configduration(
-        'block_disk_quota/over_quota_warn_email_frequency',
-        get_string('over_quota_warn_email_frequency', 'block_disk_quota'),
-        get_string('over_quota_warn_email_frequency_desc', 'block_disk_quota'),
-        3 * 24 * 60 * 60
-    ));
-*/
-
     $settings->add(new admin_setting_configduration(
         'block_disk_quota/over_quota_warn_email_frequency',
         get_string('over_quota_warn_email_frequency', 'block_disk_quota'),

--- a/settings.php
+++ b/settings.php
@@ -42,6 +42,13 @@ if ($ADMIN->fulltree) {
         get_string('enabled_desc', 'block_disk_quota'),
         0));
 
+    //P.T. 29-09-2022: added setting option for automatical site-blockage when hardlimit is reached
+    $settings->add(new admin_setting_configcheckbox(
+        'block_disk_quota/block_site_enabled',
+        get_string('block_site_enabled', 'block_disk_quota'),
+        get_string('block_site_enabled_desc', 'block_disk_quota'),
+        0));
+
     $settings->add(new admin_setting_configselect(
         'block_disk_quota/quota_gb',
         get_string('quota_gb', 'block_disk_quota'),
@@ -81,12 +88,23 @@ if ($ADMIN->fulltree) {
         14 * 24 * 60 * 60
     ));
 
+/*
+//original
     $settings->add(new admin_setting_configduration(
         'block_disk_quota/over_quota_warn_email_frequency',
         get_string('over_quota_warn_email_frequency', 'block_disk_quota'),
         get_string('over_quota_warn_email_frequency_desc', 'block_disk_quota'),
         3 * 24 * 60 * 60
     ));
+*/
+
+    $settings->add(new admin_setting_configduration(
+        'block_disk_quota/over_quota_warn_email_frequency',
+        get_string('over_quota_warn_email_frequency', 'block_disk_quota'),
+        get_string('over_quota_warn_email_frequency_desc', 'block_disk_quota'),
+        3 * 24 * 60 * 60
+      ));
+
 
     $settings->add(new admin_setting_configtext(
         'block_disk_quota/support_telephone',

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022093000;         // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2022093001;         // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2014051200;         // minimum: Moodle 2.7.
 $plugin->component = 'block_disk_quota'; // Full name of the plugin (used for diagnostics).
 $plugin->release   = '1.0';

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020060400;         // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2022093000;         // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2014051200;         // minimum: Moodle 2.7.
 $plugin->component = 'block_disk_quota'; // Full name of the plugin (used for diagnostics).
 $plugin->release   = '1.0';


### PR DESCRIPTION
- created new dev-branch 'option-auto-site-block'
- in plugin-settings (gui); added option to enable/disable automatic deactivation of site
- updated conditions for notification function
- added language-strings (en, fr, de): 
  - changes in gui (plugin-settings)
  - added new email-texts for notification-messages:
	-> usage nearing quota (with auto-blockage disabled) -> 'nearing_quota_noblock'
	-> usage over quota (with auto-blockage disabled) -> 'over_quota_noblock'
	-> usage over 'hardlimit' -> sending usage over quota message -> 'over_quota_noblock' 
- updated version.php

- when running scheduled task 'get_disk_usage': encountered a 'depricated function' warninig:

> ++ get_all_user_name_fields() is deprecated. Please use the \core_user\fields API instead ++
> * line 3381 of /lib/deprecatedlib.php: call to debugging()
> * line 117 of /blocks/disk_quota/classes/usage/quota_manager.php: call to get_all_user_name_fields()
> * line 103 of /blocks/disk_quota/classes/usage/quota_manager.php: call to block_disk_quota\usage\quota_manager->fake_user_from_bare_email_address()
> * line 182 of /blocks/disk_quota/classes/usage/quota_manager.php: call to block_disk_quota\usage\quota_manager->notification_users()
> * line 165 of /blocks/disk_quota/classes/usage/quota_manager.php: call to block_disk_quota\usage\quota_manager->notify_if_necessary()
> * line 53 of /blocks/disk_quota/classes/task/get_disk_usage.php: call to block_disk_quota\usage\quota_manager->notify_near_quota()
> * line 253 of /lib/cronlib.php: call to block_disk_quota\task\get_disk_usage->execute()
> * line 167 of /admin/cli/scheduled_task.php: call to cron_run_inner_scheduled_task()
> 

TODO: 
- replace deprecated function with new API (all features of this and some other functions have been subsumed in it, starting from v3.11)
	--> https://docs.moodle.org/dev/User_fields
- make change downwords compatible for older Moodle versions (=<3.11)